### PR TITLE
Show newsposts, links to social media underneath each page

### DIFF
--- a/src/components/Extras/ExtrasPage.vue
+++ b/src/components/Extras/ExtrasPage.vue
@@ -40,35 +40,11 @@ export default {
       return typeof this.pageData == 'string' ? this.pageData : this.pageData[this.routeParams.p].content
     },
   },
-  methods:{
-    filterLinksAndImages(){
-      let el = this.$el.querySelector('.pageContent')
-
-      // Check if this is a comment
-      if (el.nodeType !== 8){
-        let links = el.getElementsByTagName('A')
-        for(let i = 0;i < links.length; i++) {
-          links[i].href = this.$filterURL(links[i].href)
-        }
-        
-        //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-        let images = el.getElementsByTagName('IMG')
-        for(let i = 0;i < images.length; i++) {
-          images[i].src = this.$mspaURL(images[i].src)
-          images[i].ondragstart = (e) => {
-            e.preventDefault()
-            e.dataTransfer.effectAllowed = 'copy'
-            require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-          }
-        }
-      }
-    }
-  },
   updated() {
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.pageContent'))
   },
   mounted() {
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.pageContent'))
   }
 }
 </script>

--- a/src/components/Music/Album.vue
+++ b/src/components/Music/Album.vue
@@ -154,27 +154,10 @@ export default {
       let d = new Date(date)
       let month = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][d.getUTCMonth()]
       return `${month} ${d.getUTCDate()}, ${d.getUTCFullYear()}`
-    },
-    filterCommentaryLinksAndImages(){
-      let links = this.$refs.commentary.getElementsByTagName('A')
-      for(let i = 0;i < links.length; i++) {
-        links[i].href = this.$filterURL(links[i].href)
-      }
-      
-      //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-      let images = this.$refs.commentary.getElementsByTagName('IMG')
-      for(let i = 0;i < images.length; i++) {
-        images[i].src = this.$mspaURL(images[i].src)
-        images[i].ondragstart = (e) => {
-          e.preventDefault()
-          e.dataTransfer.effectAllowed = 'copy'
-          require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-        }
-      }
     }
   },
   mounted(){
-    if (this.album.commentary && this.$refs.commentary) this.filterCommentaryLinksAndImages()
+    if (this.album.commentary && this.$refs.commentary) this.$filterLinksAndImages(this.$refs.commentary)
   }
 }
 </script>

--- a/src/components/Music/Track.vue
+++ b/src/components/Music/Track.vue
@@ -176,27 +176,10 @@ export default {
       let d = new Date(date)
       let month = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][d.getUTCMonth()]
       return `${month} ${d.getUTCDate()}, ${d.getUTCFullYear()}`
-    },
-    filterCommentaryLinksAndImages(){
-      let links = this.$refs.commentary.getElementsByTagName('A')
-      for(let i = 0;i < links.length; i++) {
-        links[i].href = this.$filterURL(links[i].href)
-      }
-      
-      //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-      let images = this.$refs.commentary.getElementsByTagName('IMG')
-      for(let i = 0;i < images.length; i++) {
-        images[i].src = this.$mspaURL(images[i].src)
-        images[i].ondragstart = (e) => {
-          e.preventDefault()
-          e.dataTransfer.effectAllowed = 'copy'
-          require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-        }
-      }
     }
   },
   mounted(){
-    if (this.track.commentary && this.$refs.commentary) this.filterCommentaryLinksAndImages()
+    if (this.track.commentary && this.$refs.commentary) this.$filterLinksAndImages(this.$refs.commentary)
   }
 }
 </script>

--- a/src/components/Page/Page.vue
+++ b/src/components/Page/Page.vue
@@ -22,7 +22,7 @@
       </div>
     </div>
     <PageFooter :pageWidth="scratchIntermission ? '940px' : hscroll ? '1200px' : '950px'" />
-    <PageNews :thisPage="thisPage" />
+    <PageNews :thisPage="thisPage"/>
   </div>
 </template>
 

--- a/src/components/Page/Page.vue
+++ b/src/components/Page/Page.vue
@@ -22,7 +22,7 @@
       </div>
     </div>
     <PageFooter :pageWidth="scratchIntermission ? '940px' : hscroll ? '1200px' : '950px'" />
-    <PageNews :thisPage="thisPage"/>
+    <PageNews :thisPage="thisPage" v-if="showNewsposts"/>
   </div>
 </template>
 
@@ -119,6 +119,9 @@ export default {
     },
     fireflies() {
       return this.thisPage.flag.includes('FIREFLY')
+    },
+    showNewsposts() {
+      return this.$localData.settings.newsposts;
     },
     footnote() {
       return (this.$archive.mspa.footnotes && this.$localData.settings.footnotes && this.thisPage.pageId in this.$archive.mspa.footnotes) ? this.$archive.mspa.footnotes[this.thisPage.pageId] : undefined

--- a/src/components/Page/Page.vue
+++ b/src/components/Page/Page.vue
@@ -119,21 +119,6 @@ export default {
     },
     footnote() {
       return (this.$archive.mspa.footnotes && this.$localData.settings.footnotes && this.thisPage.pageId in this.$archive.mspa.footnotes) ? this.$archive.mspa.footnotes[this.thisPage.pageId] : undefined
-    },
-    footerBanner() {            
-      let num = parseInt(this.pageNum)
-      switch (this.$root.theme) {
-        case 'scratch':
-          return 'customScratchFooter.png'
-        case 'sbahj':
-          return 'mspalogo_sbahj.jpg'
-        case 'trickster':
-          return 'trickster_sitegraphics/bannerframe2.gif'
-        case 'A6A6':
-          return 'a6a6_bannerframe.png'
-        default:
-          return 'bannerframe.png'
-      }
     }
   },
   methods:{

--- a/src/components/Page/Page.vue
+++ b/src/components/Page/Page.vue
@@ -22,6 +22,7 @@
       </div>
     </div>
     <PageFooter :pageWidth="scratchIntermission ? '940px' : hscroll ? '1200px' : '950px'" />
+    <PageNews :thisPage="thisPage" />
   </div>
 </template>
 
@@ -33,9 +34,11 @@ import Media from '@/components/UIElements/MediaEmbed.vue'
 import TextContent from '@/components/Page/PageText.vue'
 import PageNav from '@/components/Page/PageNav.vue'
 import PageFooter from '@/components/Page/PageFooter.vue'
+import PageNews from '@/components/Page/PageNews.vue'
 
 import Firefly from '@/components/SpecialPages/Firefly.vue'
 import FlashCredit from '@/components/UIElements/FlashCredit.vue'
+
 
 export default {
   name: 'page',
@@ -43,7 +46,7 @@ export default {
     'tab', 'routeParams'
   ],
   components: {
-    NavBanner, Banner, Media, TextContent, PageNav, PageFooter, Firefly, FlashCredit
+    NavBanner, Banner, Media, TextContent, PageNav, PageFooter, PageNews, Firefly, FlashCredit
   },
   data: function() {
     return {

--- a/src/components/Page/PageNews.vue
+++ b/src/components/Page/PageNews.vue
@@ -2,6 +2,15 @@
     <div class="newsBody">
     <div class="news">
         <Media class="logo" :url="newsLogo" />
+        <div v-if="tumblr">
+            Latest Tumblr post: <a :href="tumblr.link">{{tumblr.formattedDate}}</a>
+        </div>
+        <div v-if="formspring">
+            Latest Formspring answer: <a :href="formspring.link">{{formspring.formattedDate}}</a>
+        </div>
+        <div v-if="blogspot">
+            Latest Blogspot post: <a :href="blogspot.link">{{blogspot.title}}</a>
+        </div>
         <div v-for="post in newsposts" v-html="post.html" :key="post.id"><br><br></div>
     </div>
     </div>
@@ -41,6 +50,53 @@ export default {
             prevNewsposts.sort((a, b) => b.timestamp - a.timestamp)
             prevNewsposts = prevNewsposts.slice(0, 4)
             return prevNewsposts
+        },
+        blogspot() {
+            let yesterday = this.thisPage.timestamp * 1 - 60 * 60 * 24
+            for (let blog of this.$archive.social.blogspot)
+            {
+                if (!blog.timestamp) // if user has old version of the archive
+                    return null
+                else if (blog.timestamp < yesterday)
+                {
+                    return {
+                        link: "/blogspot/" + blog.id,
+                        title: blog.title
+                    }
+                }
+            }
+            return null
+        },
+        formspring() {
+            let yesterday = this.thisPage.timestamp * 1 - 60 * 60 * 24
+            let latestPost = null;
+            for (let account in this.$archive.social.formspring)
+                for (let post of this.$archive.social.formspring[account])
+                    if (post.timestamp < yesterday && !(latestPost && latestPost.timestamp > post.timestamp))
+                        latestPost = post
+            if (!latestPost)
+                return null
+            else {
+                return {
+                    link: "/formspring/" + latestPost.id,
+                    formattedDate: new Date(latestPost.timestamp * 1000).toDateString()
+                }
+            }
+        },
+        tumblr() {
+            let yesterday = this.thisPage.timestamp * 1 - 60 * 60 * 24
+            let latestPost = null;
+            for (let post of this.$archive.social.tumblr)
+                if (post.timestamp < yesterday && !(latestPost && latestPost.timestamp > post.timestamp))
+                    latestPost = post
+            if (!latestPost)
+                return null
+            else {
+                return {
+                    link: "/tumblr/" + latestPost.id,
+                    formattedDate: new Date(latestPost.timestamp * 1000).toDateString()
+                }
+            }
         }
     },
     methods: {

--- a/src/components/Page/PageNews.vue
+++ b/src/components/Page/PageNews.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="pageBody">
+    <div class="newsBody">
     <div class="news">
         <Media class="logo" :url="newsLogo" />
         <div v-for="post in newsposts" v-html="post.html" :key="post.id"><br><br></div>
@@ -55,6 +55,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+    .newsBody { // these rules keep it centered on x2 combo pages
+        display: flex;
+        flex-flow: column;
+        align-items: center;
+        align-self: center;
+    }
     .sbahj .logo::before {
         content: "NEWNS";
         font-size: 24px;
@@ -65,6 +71,7 @@ export default {
         font-size: 12px;
         font-weight: normal;
         text-align: justify;
+        align-items: normal;
 
         display: flex;
         flex-flow: column;

--- a/src/components/Page/PageNews.vue
+++ b/src/components/Page/PageNews.vue
@@ -1,0 +1,102 @@
+<template>
+    <div class="pageBody">
+    <div class="news">
+        <Media class="logo" :url="newsLogo" />
+        <div v-for="post in newsposts" v-html="post.html" :key="post.id"><br><br></div>
+    </div>
+    </div>
+</template>
+
+
+<script>
+import Media from '@/components/UIElements/MediaEmbed.vue'
+
+export default {
+    name: 'pageNews',
+    components: {
+        Media
+    },
+    props: [
+        'thisPage'
+    ],
+    data() {
+        return{}
+    },
+    computed: {
+        newsLogo() {
+            return this.$root.theme === 'A6A6'       ? '/images/a6a6_news.png' :
+                   this.$root.theme === 'scratch'
+                   || this.$root.theme === 'sbahj'   ? '' :
+                   this.$root.theme === 'retro'      ? 'images/retro_news.gif' :
+                   this.$root.theme === 'pxs'        ? 'images/pxs_news.png' :
+                                                       '/images/news.png'
+        },
+        newsposts() {
+            let yesterday = this.thisPage.timestamp * 1 - 60 * 60 * 24
+            let prevNewsposts = []
+            for (let year in this.$archive.social.news)
+                for (let post of this.$archive.social.news[year])
+                    if (yesterday > post.timestamp)
+                        prevNewsposts.push(post)
+            prevNewsposts.sort((a, b) => b.timestamp - a.timestamp)
+            prevNewsposts = prevNewsposts.slice(0, 4)
+            return prevNewsposts
+        }
+    },
+    methods: {
+    },
+    updated(){
+        this.$filterLinksAndImages(this.$el.querySelector('.news'))
+    },
+    mounted(){
+        this.$filterLinksAndImages(this.$el.querySelector('.news'))
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+    .sbahj .logo::before {
+        content: "NEWNS";
+        font-size: 24px;
+    }
+    .news {
+        background: var(--page-news);
+        font-family: Verdana, Arial, Helvetica, sans-serif;
+        font-size: 12px;
+        font-weight: normal;
+        text-align: justify;
+
+        display: flex;
+        flex-flow: column;
+        flex: 1 0 auto;
+        img {
+            align-self: center;
+            max-width: 100%;
+            object-fit: contain;
+        }
+
+        width: 420px; // dude weed lmao
+        padding-left: 25px;
+        padding-right: 30px;
+        padding-top: 20px;
+        padding-bottom: 20px;
+
+        margin: 10px;
+    }
+    div::v-deep .date.link {
+        font-style: italic;
+        ::before {
+            content: "Posted on ";
+        }
+        margin-top: 30px;
+        padding-bottom: 3px;
+        border-bottom: 1px solid rgb(211, 211, 211);
+        margin-bottom: 7px;
+    }
+    div::v-deep a {
+        color: var(--page-links);
+    }
+    .A6A6 div::v-deep {
+        color: #000000;
+    }
+</style>

--- a/src/components/Socials/Blogspot.vue
+++ b/src/components/Socials/Blogspot.vue
@@ -233,30 +233,6 @@ export default {
       else {
         document.getElementById(this.$localData.tabData.activeTabKey).scrollTop = 0
       }
-    },
-    filterLinksAndImages(){
-      let el = this.$el.querySelector('.main-wrapper')
-
-      // Check if this is a comment
-      if (el.nodeType !== 8){
-        let links = el.getElementsByTagName('A')
-        for(let i = 0;i < links.length; i++) {
-          links[i].href = this.$filterURL(links[i].href)
-        }
-        
-        //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-        let images = [...el.getElementsByTagName('IMG'), ...el.getElementsByTagName('VIDEO')]
-        for(let i = 0;i < images.length; i++) {
-          images[i].src = this.$mspaURL(images[i].src)
-          if (images[i].tagName == 'IMG') {  
-            images[i].ondragstart = (e) => {
-              e.preventDefault()
-              e.dataTransfer.effectAllowed = 'copy'
-              require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-            }
-          }
-        }
-      }
     }
   },
   watch: {
@@ -265,11 +241,11 @@ export default {
     }
   },
   updated() {
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.main-wrapper'))
   },
   mounted(){
     this.jumpToClass(this.routeParams.id)
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.main-wrapper'))
   }
 }
 </script>

--- a/src/components/Socials/DStrider.vue
+++ b/src/components/Socials/DStrider.vue
@@ -131,30 +131,6 @@ export default {
       else {
         document.getElementById(this.$localData.tabData.activeTabKey).scrollTop = 0
       }
-    },
-    filterLinksAndImages(){
-      let el = this.$el.querySelector('.main-wrapper')
-
-      // Check if this is a comment
-      if (el.nodeType !== 8){
-        let links = el.getElementsByTagName('A')
-        for(let i = 0;i < links.length; i++) {
-          links[i].href = this.$filterURL(links[i].href)
-        }
-        
-        //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-        let images = [...el.getElementsByTagName('IMG'), ...el.getElementsByTagName('VIDEO')]
-        for(let i = 0;i < images.length; i++) {
-          images[i].src = this.$mspaURL(images[i].src)
-          if (images[i].tagName == 'IMG') {  
-            images[i].ondragstart = (e) => {
-              e.preventDefault()
-              e.dataTransfer.effectAllowed = 'copy'
-              require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-            }
-          }
-        }
-      }
     }
   },
   watch: {
@@ -163,11 +139,11 @@ export default {
     }
   },
   updated() {
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.main-wrapper'))
   },
   mounted(){
     this.jumpToClass(this.routeParams.id)
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.main-wrapper'))
   }
 }
 </script>

--- a/src/components/Socials/Formspring.vue
+++ b/src/components/Socials/Formspring.vue
@@ -103,7 +103,7 @@ export default {
   },
   watch: {
     'tab.history': function (to, from) {
-      if (/^question/.test(this.routeParams.id) && this.$isNewReader) this.profile = 'mspadventures'
+      if (/^question/.test(this.routeParams.id) && !this.$pageIsSpoiler('005198')) this.profile = 'mspadventures'
       else this.profile = 'andrewhussie'
 
       this.jumpToClass(this.routeParams.id)
@@ -113,7 +113,7 @@ export default {
     this.jumpToClass(this.routeParams.id)
   },
   created(){
-    if (/^question/.test(this.routeParams.id) && this.$isNewReader) this.profile = 'mspadventures'
+    if (/^question/.test(this.routeParams.id) && !this.$pageIsSpoiler('005198')) this.profile = 'mspadventures'
     else this.profile = 'andrewhussie'
   }
 }

--- a/src/components/Socials/News.vue
+++ b/src/components/Socials/News.vue
@@ -75,30 +75,6 @@ export default {
       else {
         document.getElementById(this.$localData.tabData.activeTabKey).scrollTop = 0
       }
-    },
-    filterLinksAndImages(){
-      let el = this.$el.querySelector('.pageContent')
-
-      // Check if this is a comment
-      if (el.nodeType !== 8){
-        let links = el.getElementsByTagName('A')
-        for(let i = 0;i < links.length; i++) {
-          links[i].href = this.$filterURL(links[i].href)
-        }
-        
-        //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-        let images = [...el.getElementsByTagName('IMG'), ...el.getElementsByTagName('VIDEO')]
-        for(let i = 0;i < images.length; i++) {
-          images[i].src = this.$mspaURL(images[i].src)
-          if (images[i].tagName == 'IMG') {  
-            images[i].ondragstart = (e) => {
-              e.preventDefault()
-              e.dataTransfer.effectAllowed = 'copy'
-              require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-            }
-          }
-        }
-      }
     }
   },
   watch: {
@@ -113,7 +89,7 @@ export default {
     }
   },
   updated(){
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.pageContent'))
   },
   mounted(){
     if (this.routeParams.id) {
@@ -121,7 +97,7 @@ export default {
       if (year in this.$archive.social.news) this.activeYear = year
     }
     setTimeout(() => {this.jumpToClass(this.routeParams.id)}, 0)
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.pageContent'))
   }
 }
 </script>

--- a/src/components/Socials/Tumblr.vue
+++ b/src/components/Socials/Tumblr.vue
@@ -82,30 +82,6 @@ export default {
       else {
         document.getElementById(this.$localData.tabData.activeTabKey).scrollTop = 0
       }
-    },
-    filterLinksAndImages(){
-      let el = this.$el.querySelector('.content')
-
-      // Check if this is a comment
-      if (el.nodeType !== 8){
-        let links = el.getElementsByTagName('A')
-        for(let i = 0;i < links.length; i++) {
-          links[i].href = this.$filterURL(links[i].href)
-        }
-        
-        //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
-        let images = [...el.getElementsByTagName('IMG'), ...el.getElementsByTagName('VIDEO')]
-        for(let i = 0;i < images.length; i++) {
-          images[i].src = this.$mspaURL(images[i].src)
-          if (images[i].tagName == 'IMG') {  
-            images[i].ondragstart = (e) => {
-              e.preventDefault()
-              e.dataTransfer.effectAllowed = 'copy'
-              require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
-            }
-          }
-        }
-      }
     }
   },
   watch: {
@@ -114,11 +90,11 @@ export default {
     }
   },
   updated(){
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.content'))
   },
   mounted(){
     this.jumpToClass(this.routeParams.id)
-    this.filterLinksAndImages()
+    this.$filterLinksAndImages(this.$el.querySelector('.content'))
   }
 }
 </script>

--- a/src/components/SpecialPages/x2Combo.vue
+++ b/src/components/SpecialPages/x2Combo.vue
@@ -33,6 +33,7 @@
       </div>
     </div>
     <PageFooter pageWidth="1660px" />
+    <PageNews :thisPage="thisPage[1]" />
   </div>
 </template>
 
@@ -44,6 +45,7 @@ import Media from '@/components/UIElements/MediaEmbed.vue'
 import TextContent from '@/components/Page/PageText.vue'
 import PageNav from '@/components/SpecialPages/x2ComboNav.vue'
 import PageFooter from '@/components/Page/PageFooter.vue'
+import PageNews from '@/components/Page/PageNews.vue'
 
 export default {
   name: 'x2Combo',
@@ -51,7 +53,7 @@ export default {
     'tab', 'routeParams'
   ],
   components: {
-    NavBanner, Banner, Media, TextContent, PageNav, PageFooter
+    NavBanner, Banner, Media, TextContent, PageNav, PageFooter, PageNews
   },
   data: function() {
     return {

--- a/src/components/SystemPages/Settings.vue
+++ b/src/components/SystemPages/Settings.vue
@@ -65,7 +65,10 @@
 
           <dt><label><input type="checkbox" name="credits" v-model="$localData.settings['credits']" @click="toggleSetting('credits')">Show inline audio credits</label></dt>
           <dd class="settingDesc">Inserts audio credits below pages that use music. It shows you the name of the song, the artists involved, and has a link to the track's page in the music database.</dd>
-          
+
+          <dt><label><input type="checkbox" name="newsposts" v-model="$localData.settings['newsposts']" @click="toggleSetting('newsposts')">Show news posts below each page</label></dt>
+          <dd class="settingDesc">Shows the news posts that were present below each page when the page was originally posted on mspaintadventures.com. Also displays links to the contemporary latest posts on Andrew Hussie's public fan-focused social media.</dd>
+
           <dt v-if="this.$archive.mspa.footnotes"><label><input type="checkbox" name="footnotes" v-model="$localData.settings['openLogs']" @click="toggleSetting('footnotes')">Display footnotes</label></dt>
           <dd v-if="this.$archive.mspa.footnotes" class="settingDesc">Display footnotes beneath MSPA pages.</dd>
         </dl>

--- a/src/components/SystemPages/Settings.vue
+++ b/src/components/SystemPages/Settings.vue
@@ -106,7 +106,7 @@
           <dd class="settingDesc">During the trickster segment of Act 6 Act 5, <a href="/mspa/007623" target="_blank">there was originally a joke regarding the skin-colour of the Trickster kids</a>. This was received poorly by the fanbase, <a href="/tumblr/more-so-i-just-dialed-down-the-joke-on-page" target="_blank">and toned down shortly after.</a></dd>
           
           <dt><label><input type="checkbox" name="pxsTavros" v-model="$localData.settings['pxsTavros']" @click="toggleSetting('pxsTavros')">Paradox Space - Tavros Banana</label></dt>
-          <dd class="settingDesc">During the original run of Paradox Space's Summerteen Romance story, <a href="/pxs/summerteen-romance/31" target="_blank">one page had a somewhat heavy focus on body horror</a>. The original version was completely unobscured, but it was hastily censored.</a></dd>
+          <dd class="settingDesc">During the original run of Paradox Space's Summerteen Romance story, <a href="/pxs/summerteen-romance/31" target="_blank">one page had a somewhat heavy focus on body horror</a>. The original version was completely unobscured, but it was hastily censored.</dd>
           
           <dt><label><input type="checkbox" name="cursedHistory" v-model="$localData.settings['cursedHistory']" @click="toggleSetting('cursedHistory')">Skaianet Systems - CURSED_HISTORY</label></dt>
           <dd class="settingDesc">At the beginning of 2019, <a href="/skaianet" target="_blank">the Skaianet Systems website launched</a>, with some of Hussie's old worldbuilding notes peppered through the source code. Many people found the the notes to be in extremely poor taste, and they were swiftly removed.</dd>

--- a/src/css/mspaThemes.scss
+++ b/src/css/mspaThemes.scss
@@ -23,6 +23,7 @@
 	--page-log-bg: #EEEEEE;
 	--page-nav-divider: #000000;
 	--page-nav-meta: #535353;
+	--page-news: #EFEFEF;
 	--page-links: #0000EE;
 	--page-links-visited: #6300c0;
 
@@ -86,6 +87,7 @@
 		--page-log-bg: #000000;
 		--page-nav-divider: #FFFFFF;
 		--page-nav-meta: #FFFFFF;
+		--page-news: #0E4603;
 		--page-links: #2cff4b;
 		--page-links-visited: #2cff4b;
 
@@ -116,6 +118,7 @@
 		--page-pageFrame: #f400ec;
 		--page-pageContent: #14ff23;
 		--page-nav-meta: #000000;
+		--page-news: #14ff23;
 
 		--ctx-bg: #f400ec;
 		--ctx-frame: #0707ec;
@@ -159,6 +162,7 @@
 		--page-pageBorder: #6a6a6a;
 		--page-nav-divider: #0066ff;
 		--page-nav-meta: #0066ff;
+		--page-news: #262626;
 		--page-links: #0066ff;
 		
 		--ctx-bg: #262626;
@@ -193,6 +197,7 @@
 		--page-pageContent: #363636;
 		--page-nav-divider: red;
 		--page-nav-meta: red;
+		--page-news: #363636;
 		--page-links: red;
 		
 		--ctx-bg: #262626;
@@ -229,6 +234,7 @@
 		--page-pageContent: #111111;
 		--page-nav-divider: #A1EE26;
 		--page-nav-meta: #A1EE26;
+		--page-news: #111111;
 		--page-links: #A1EE26;
 		
 		--ctx-bg: #2f2f2f;
@@ -267,6 +273,7 @@
 		--page-log-bg: #ff73fd;
 		--page-nav-divider: #f9fd6b;
 		--page-nav-meta: #f9fd6b;
+		--page-news: #ff73fd;
 		--page-links: #fb060b;
 		--page-links-visited: #f9fd6b;
 
@@ -323,6 +330,7 @@
 		// --page-log-bg: #000000;
 		--page-nav-divider: #000000;
 		--page-nav-meta: #2ed73a;
+		--page-news: #126D00;
 		--page-links: #2ed73a;
 
 		--ctx-bg: #073c00;
@@ -368,6 +376,7 @@
 		// --page-log-bg: #EEEEEE;
 		--page-nav-divider: #ffffff;
 		--page-nav-meta: #72abd2;
+		--page-news: #095486;
 		--page-links: #72abd2;
 		--page-links-visited: #ffffff;
 	

--- a/src/main.js
+++ b/src/main.js
@@ -108,6 +108,28 @@ Vue.mixin({
       if (resource.charAt(0) == '/') resource = resource.slice(1)
       return this.$localhost + resource
     },
+    $filterLinksAndImages(el){
+      // Check if this is a comment
+      if (el.nodeType !== 8){
+        let links = el.getElementsByTagName('A')
+        for(let i = 0;i < links.length; i++) {
+          links[i].href = this.$filterURL(links[i].href)
+        }
+
+        //Normally, this process would be handled by the MediaEmbed component. Gotta get the behaviour into all them images somehow!
+        let images = [...el.getElementsByTagName('IMG'), ...el.getElementsByTagName('VIDEO')]
+        for(let i = 0;i < images.length; i++) {
+          images[i].src = this.$mspaURL(images[i].src)
+          if (images[i].tagName == 'IMG') {
+            images[i].ondragstart = (e) => {
+              e.preventDefault()
+              e.dataTransfer.effectAllowed = 'copy'
+              require('electron').ipcRenderer.send('ondragstart', this.$mspaFileStream(images[i].src))
+            }
+          }
+        }
+      }
+    },
     $getStory(pageNumber){
       pageNumber = parseInt(pageNumber) || pageNumber
 

--- a/src/store/localData.js
+++ b/src/store/localData.js
@@ -59,6 +59,7 @@ class LocalData {
       hqAudio: true,
       jsFlashes: true,
       credits: true,
+      newsposts: false,
       footnotes: false,
 
       retcon1: true,


### PR DESCRIPTION
Sample screenshot
![image](https://user-images.githubusercontent.com/6370042/97900709-bd3f7900-1d43-11eb-86c3-72b29c58a2ab.png)


Note that this requires an update to the asset pack, mostly in social.json in order to get timestamp and title data for the blogspot posts, but also several images for different news logos (see newsLogo() in PageNews.vue) (if youre going to accept this PR ill pm them to you on discord or something). It won't harm the experience if you still have v1.0, but not everything from this PR will show up.

Open questions:
* Should the option be on by default? Probably not
* How should the news posts themselves be styled? MSPA had a surprising variety of ways over the years
* Should it stop showing the latest social media after a while (probably yeah)?
* Should tumblr and formspring also show the post/question title? (almost definitely but i'm lazy and it requires editing the asset pack even further)
