### PR TITLE
Add workaround for coloUrs and mayhem case

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -61,6 +61,9 @@ try {
 
   archive.music.tracks['ascend'].commentary = archive.music.tracks['ascend'].commentary.replace('the-king-in-red>The', 'the-king-in-red">The')
 
+  archive.music.albums['colours-and-mayhem-universe-a'].directory = 'coloUrs-and-mayhem-universe-a';
+  archive.music.albums['colours-and-mayhem-universe-b'].directory = 'coloUrs-and-mayhem-universe-b';
+
 
   //Pick the appropriate flash plugin for the user's platform
   let flashPlugin

--- a/src/components/Music/Track.vue
+++ b/src/components/Music/Track.vue
@@ -77,6 +77,7 @@ export default {
     trackArtPath() {
       let dirName = this.track.album.find(album => this.$archive.music.albums[album].hasTrackArt && !this.$albumIsSpoiler(album)) || this.track.album[0]
       let fileName = this.track.coverArtists && this.$archive.music.albums[dirName].hasTrackArt ? this.track.directory : 'cover'
+      dirName = dirName.replace(/^colours/, 'coloUrs'); // FIXME: temporary workaround for asset pack issue
       return (this.$albumIsSpoiler(dirName) ) ? `/archive/music/spoiler.png` : `/archive/music/${dirName}/${fileName}.jpg`
     },
     linkAndJoinAlbums() {


### PR DESCRIPTION
coloUrs and mayhem has the U capitalized in its asset pack filename.
This breaks track/album art on case-sensitive filesystems.

Fixes #4