### PR TITLE
Add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ develop ]
   schedule:
     - cron: '31 18 * * 4'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,28 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '31 18 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: 'javascript'
+        queries: security-and-quality
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Slight disclaimer, I work at GitHub in the code scanning team, however I've also read Homestuck and I think this project to preserve it is awesome.

This PR adds a workflow that runs CodeQL analysis to find security problems and other programming errors. It's a pretty good tool for finding code problems and stopping them from being introduced in new PRs. Entirely up to you if you wantto use it. You can read a bit more at https://docs.github.com/en/code-security/secure-coding/about-code-scanning.

Unfortunately due to this being the first analysis and being from a fork you may not be able to see the list of alerts before merging but I once it is merged the workflow will run nightly as well as on new PRs and will tell you how many alerts are introduced or fixed by the PR. I have run the analysis myself so I can tell you the list of things it has found if you like.