### PR TITLE
text features

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sass": "^1.35.1",
     "serve-handler": "^6.1.3",
     "tar": "^6.1.11",
+    "ts-color-class": "^0.10.1",
     "unzipper": "^0.10.11",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,12 +10,6 @@
     <Updater ref="Updater" />
     <UrlTooltip :class="theme" ref="urlTooltip" v-if="$localData.settings.urlTooltip"/>
     <component is="style" v-for="s in stylesheets" :id="s.id" :key="s.id" rel="stylesheet" v-text="s.body"/>
-    <component is="style" v-if="$localData.settings.textOverride.paragraphSpacing">
-      .log .logContent span {
-        padding-bottom: 0.5em;
-        display: inline-block;
-      }
-    </component>
   </div>
   <div id="app" class="mspa"  v-else>
     <Setup />

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,12 @@
     <Updater ref="Updater" />
     <UrlTooltip :class="theme" ref="urlTooltip" v-if="$localData.settings.urlTooltip"/>
     <component is="style" v-for="s in stylesheets" :id="s.id" :key="s.id" rel="stylesheet" v-text="s.body"/>
+    <component is="style" v-if="$localData.settings.textOverride.paragraphSpacing">
+      .log .logContent span {
+        padding-bottom: 0.5em;
+        display: inline-block;
+      }
+    </component>
   </div>
   <div id="app" class="mspa"  v-else>
     <Setup />

--- a/src/components/Page/PageText.vue
+++ b/src/components/Page/PageText.vue
@@ -2,7 +2,7 @@
     <p class="prattle text" :class="fontFamily" :style="fontScale" v-html="filteredPrattle" v-if="textType == 'prattle' && !!content"></p>
 
     <div class="log" :class="{logHidden: logHidden}" v-else-if="textType == 'log'">
-        <div class="bgshade" v-if="$localData.settings.textOverride.highContrast"/>
+        <div class="bgshade" v-if="$localData.settings.textOverride.highContrast" :style="{background: isDarkMode ? '#000A' : '#FFFA'}"/>
 		<button class="logButton" @click="loggle()">
             {{ logButtonText }}
 		</button>
@@ -18,7 +18,7 @@
 <script>
 export default {
     name: 'pageText',
-    props: ['pageId', 'content'],
+    props: ['pageId', 'content', 'forcetheme'],
     data() {
         return {
             usePurpleLinks: false,
@@ -49,13 +49,23 @@ export default {
             if (this.$localData.settings.textOverride.fontFamily) result.push(this.$localData.settings.textOverride.fontFamily)
             return result
         },
+        theme(){
+            return this.forcetheme || this.$root.tabTheme
+        },
+        isDarkMode() {
+            return ['cascade'].includes(this.theme)
+        },
         fontScale() {
             let fontSizes = ['1em', '1.15em', '1.3em', '1.45em', '1.6em', '1.75em', '1.9em']
             let lineHeights = [1.15, 1.35, 1.5, 1.65, 1.85, 2, 2.15]
+
+            console.log(this.theme)
+            let contrastFilter = this.isDarkMode ? "contrast(0.5) brightness(2)" : "brightness(0.7)"
             return {
                 fontSize: fontSizes[this.$localData.settings.textOverride.fontSize],
                 lineHeight: lineHeights[this.$localData.settings.textOverride.lineHeight],
-                filter: this.$localData.settings.textOverride.highContrast ? "brightness(0.7)" : "none"
+                filter: this.$localData.settings.textOverride.highContrast ? contrastFilter : "none",
+                color: this.isDarkMode ? "white" : "var(--font-log)"
             }
         },
         textType() {
@@ -242,7 +252,6 @@ export default {
             width: 100%;
             height: 100%;
             position: absolute;
-            background: #FFFFFFAA;
             pointer-events: none;
             top: 0;
             left: 0;

--- a/src/components/Page/PageText.vue
+++ b/src/components/Page/PageText.vue
@@ -2,6 +2,7 @@
     <p class="prattle text" :class="fontFamily" :style="fontScale" v-html="filteredPrattle" v-if="textType == 'prattle' && !!content"></p>
 
     <div class="log" :class="{logHidden: logHidden}" v-else-if="textType == 'log'">
+        <div class="bgshade" v-if="$localData.settings.textOverride.highContrast"/>
 		<button class="logButton" @click="loggle()">
             {{ logButtonText }}
 		</button>
@@ -53,7 +54,8 @@ export default {
             let lineHeights = [1.15, 1.35, 1.5, 1.65, 1.85, 2, 2.15]
             return {
                 fontSize: fontSizes[this.$localData.settings.textOverride.fontSize],
-                lineHeight: lineHeights[this.$localData.settings.textOverride.lineHeight]
+                lineHeight: lineHeights[this.$localData.settings.textOverride.lineHeight],
+                filter: this.$localData.settings.textOverride.highContrast ? "brightness(0.7)" : "none"
             }
         },
         textType() {
@@ -211,24 +213,40 @@ export default {
         padding: 1px;
         text-align: center;
         align-self: center;
+        position: relative;
         
         &.highContrast {
             background: #ffffff;
         }
         button {
             text-transform: capitalize;
+            position: inherit;
+            z-index: 10;
         }
         
         .logContent{
             color: var(--font-log);
             padding: 15px 5%;
             text-align: left;
+            z-index: 5;
         }
 
         &.logHidden {
-            .logContent {
+            .logContent, .bgshade {
                 display: none; 
             }
+
+        }
+
+        .bgshade {
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            background: #FFFFFFAA;
+            pointer-events: none;
+            top: 0;
+            left: 0;
+            z-index: 0;
         }
     }
 </style>

--- a/src/components/SystemPages/Settings.vue
+++ b/src/components/SystemPages/Settings.vue
@@ -129,10 +129,11 @@
                     </option>
                   </select>
                 </label>
-                <span v-if="$localData.settings.textOverride.fontFamily">
-                  <br><br>
-                  <label ><input type="checkbox" name="bold" v-model="$localData.settings.textOverride['bold']" @click="toggleSetting('bold', 'textOverride')"> Bold Font</label>
-                </span>
+                <div class="textOptions">
+                  <label v-if="$localData.settings.textOverride.fontFamily"><input type="checkbox" name="bold" v-model="$localData.settings.textOverride['bold']" @click="toggleSetting('bold', 'textOverride')"> Bold Font</label>
+                  <label><input type="checkbox" name="paragraphSpacing" v-model="$localData.settings.textOverride['paragraphSpacing']" @click="toggleSetting('paragraphSpacing', 'textOverride')"> Spacing between chat paragraphs</label>
+                  <label><input type="checkbox" name="highContrast" v-model="$localData.settings.textOverride['highContrast']" @click="toggleSetting('highContrast', 'textOverride')"> High contrast text</label>
+                </div>
                 <br><br>
                 <label>Font size:<input type="range" v-model="$localData.settings.textOverride.fontSize" min="0" max="6" step="1" list="fontSize"></label>
                 <br><br>
@@ -943,6 +944,10 @@ export default {
         .textOverrideSettings {
           margin-top: 16px;
           text-align: center;
+          
+          .textOptions label {
+            display: block;
+          }
 
           .textpreviews {
             border: 6px solid var(--page-pageFrame);

--- a/src/components/SystemPages/Settings.vue
+++ b/src/components/SystemPages/Settings.vue
@@ -825,7 +825,7 @@ export default {
     background-color: #35bfff;
     background-attachment: fixed;
     
-    a {
+    ::v-deep a {
       color: var(--page-links);
     }
 
@@ -1019,15 +1019,15 @@ export default {
       
       ul, ol {  
         text-align: left;
-        border: solid #c6c6c6;
-        border-width: 7px 7px 0 0;
+        border: solid var(--page-pageBorder, var(--page-pageFrame));
+        border-width: 5px 5px 0 0;
         padding-bottom: 6em;
         height: 100%;
       }
 
       li {
           /*list-style-position: inside;*/
-          background-color: #fff;
+          background-color: var(--page-log-bg);
           border: 1px solid rgba(0,0,0,.125);
           margin-bottom: -1px;
           padding: .2em;
@@ -1052,10 +1052,10 @@ export default {
         float: right;
         width: 18px;
         height: 18px;
-        background: #EEE;
+        background: var(--saves-tab);
         text-align: center;
         &:hover {
-          background: #c6c6c6
+          background: var(--saves-tabHover)
         }
       }
     }

--- a/src/components/SystemPages/Settings.vue
+++ b/src/components/SystemPages/Settings.vue
@@ -140,12 +140,13 @@
                 <label>Line height:<input type="range" v-model="$localData.settings.textOverride.lineHeight" min="0" max="6" step="1" list="lineHeight"></label>
               </div>
               <div class="textpreviews">
-                <PageText class="examplePrattle" 
+                <!-- PageText usually require a tab change to recalculate theme. -->
+                <PageText :forcetheme="$localData.settings.themeOverride" class="examplePrattle" 
                 content="A young man stands in his bedroom. It just so happens that today, the 13th of April, 2009, is this young man's birthday. Though it was thirteen years ago he was given life, it is only today he will be given a name!<br><br>What will the name of this young man be?"/>
-                <PageText class="examplePrattle" 
+                <PageText :forcetheme="$localData.settings.themeOverride" class="examplePrattle" 
                 content="|PESTERLOG|<br />-- turntechGodhead <span style=&quot;color: #e00707&quot;>[TG]</span> began pestering ectoBiologist <span style=&quot;color: #0715cd&quot;>[EB]</span> at 16:13 --<br /><br /><span style=&quot;color: #e00707&quot;>TG: hey so what sort of insane loot did you rake in today</span><br /><span style=&quot;color: #0715cd&quot;>EB: i got a little monsters poster, it's so awesome. i'm going to watch it again today, the applejuice scene was so funny.</span>"/>
                 <!-- v-if="!this.$pageIsSpoiler('001926')" -->
-                <PageText class="examplePrattle" 
+                <PageText :forcetheme="$localData.settings.themeOverride" class="examplePrattle" 
                 v-if="$localData.settings['devMode'] && !this.$pageIsSpoiler('007378')"
                 content="|AUTHORLOG|<br /><span style=&quot;color: #323232&quot;>HEY.</span><br /><span style=&quot;color: #323232&quot;>VOICE IN MY HEAD.</span><br /><span style=&quot;color: #000000&quot;>Yes?</span><br /><span style=&quot;color: #323232&quot;>SHUT UP.</span>"/>
               </div>

--- a/src/components/SystemPages/Settings.vue
+++ b/src/components/SystemPages/Settings.vue
@@ -503,6 +503,7 @@ export default {
       ],
       themes: [
         {text: "Auto", value: "default"},
+        {text: "Dark", value: "dark"},
         {text: "MSPA", value: "mspa"},
         {text: "Retro", value: "retro"},
         {text: "Scratch", value: "scratch"},
@@ -566,7 +567,7 @@ export default {
       }
     },
     darkModeChecked(){
-      if (this.$localData.settings.themeOverride == "cascade") return true
+      if (this.$localData.settings.themeOverride == "dark") return true
       else if (this.$localData.settings.themeOverride == "default") return false
       return undefined
     }
@@ -633,7 +634,7 @@ export default {
         this.$localData.settings.themeOverride = "default"
       } else {
         // Check "dark mode style"
-        this.$localData.settings.themeOverride = "cascade"
+        this.$localData.settings.themeOverride = "dark"
       }
       this.$localData.root.saveLocalStorage()
     },

--- a/src/components/UIElements/SubSettingsModal.vue
+++ b/src/components/UIElements/SubSettingsModal.vue
@@ -312,9 +312,10 @@ export default {
       background: #008C45;
     }
     ul {
-      padding: 0 0.5em;;
+      padding: 0 0.5em;
       list-style: inside;
       background: white;
+      color: black;
     }
   }
 

--- a/src/css/mspaThemes.scss
+++ b/src/css/mspaThemes.scss
@@ -52,6 +52,42 @@
 		// Use all defaults with no modifications.
 	}
 
+	&.dark {
+		--font-default: #ffffff;
+		--font-header: #ffffff;
+		--font-highlight: #000000;
+		--font-disabled: rgba(255, 255, 255, 0.2);
+		--font-ctx: #ffffff;
+
+		--header-bg: #262626;
+		--header-tabSection: #404040;
+		--header-border: #363636;
+
+		--header-buttonHoverState: rgba(255, 255, 255, 0.1);
+		--header-buttonClickState: rgba(255, 255, 255, 0.15);
+
+		--page-pageBody: #000000;
+		--page-pageFrame: #262626;
+		--page-pageContent: #393939;
+		--page-pageBorder: #6a6a6a;
+		--page-nav-divider: #0066ff;
+		--page-nav-meta: #979797;
+		--page-links: #0066ff;
+		--page-log-bg: #000000;
+		
+		--ctx-bg: #262626;
+		--ctx-frame: #000000;
+		--ctx-select: #0066ff;
+		--ctx-divider: #ffffff;
+
+		--saves-bg: #454545;
+		--saves-tab: #262626;
+		--saves-tabHover: #3c3c3c;
+		--saves-border: #363636;
+		--saves-scroll: #5a5a5a;
+		--saves-scrollHover: #6a6a6a;
+	}
+
 	&.retro {
 		--app-icon: "build/icons/default.ico";
 		

--- a/src/css/mspaThemes.scss
+++ b/src/css/mspaThemes.scss
@@ -182,6 +182,7 @@
 		--page-nav-divider: #0066ff;
 		--page-nav-meta: #0066ff;
 		--page-links: #0066ff;
+		--page-log-bg: #000000;
 		
 		--ctx-bg: #262626;
 		--ctx-frame: #000000;

--- a/src/store/localData.js
+++ b/src/store/localData.js
@@ -69,7 +69,9 @@ class LocalData {
         fontFamily: "",
         bold: false,
         fontSize: 0,
-        lineHeight: 0
+        lineHeight: 0,
+        paragraphSpacing: false,
+        highContrast: false,
       },
       arrowNav: true,
       openLogs: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9793,6 +9793,11 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-color-class@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/ts-color-class/-/ts-color-class-0.10.1.tgz#020b4d6dba2bf59f21f77bcb36445be1a30e8aca"
+  integrity sha512-FHqcpjbhHWqTzA81eMW4JvrSQcFrqVo1KhRTMfoR1GAupERAr3T/UT2u1T8ryxQVuZCW/kc4p3mv74mh2pVt+A==
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"


### PR DESCRIPTION
New text features:

High contrast text: Uses CSS filters to darken text colors (but not make them completely black) and adds a lightening shade to the back of log content.

Extra paragraph spacing: Adds paragraph spacing between pesterlog/dialog lines

Compare both disabled/enabled:

![image](https://user-images.githubusercontent.com/6759280/152487327-77f74c14-1f11-4c18-af89-79808b0b8445.png)

![image](https://user-images.githubusercontent.com/6759280/152487257-8d9a6b25-9a83-4ebc-9827-184596665825.png)
