### PR TITLE
Resource path fix

### DIFF
--- a/src/components/UIElements/MediaModal.vue
+++ b/src/components/UIElements/MediaModal.vue
@@ -6,7 +6,7 @@
           <MediaEmbed :url="url" ref="media" webarchive="true" @blockedevent="onBlockedEvent"/>
         </div>
         <div class="modalLinks">
-          <span v-text="splitPath[0]" @click.prevent="openItemInFolder" /> - <span v-text="splitPath[1].replace(/%20/g, ' ')" @click.prevent="openItem" />
+          <span v-text="splitPath[0]" @click.prevent="openItemInFolder" /> - <span v-text="splitPath[1]" @click.prevent="openItem" />
         </div>
         <FlashCredit :pageId="this.contentId"/>
       </div>
@@ -34,8 +34,13 @@ export default {
   },
   computed: {
     splitPath() {
+      const filteredUrl = this.url
+        .replace(/^http(s{0,1}):\/\/127\.0\.0\.1:[0-9]+/, '')
+        .replace(/^assets:\/\//, '')
+      const filePath = filteredUrl.slice(0, filteredUrl.lastIndexOf('/'))
+      const fileName = filteredUrl.slice(filteredUrl.lastIndexOf('/')+1).replace(/%20/g, ' ')
       // Returns folder that the file is stored in, and the filename itself
-      return [this.url.slice(0, this.url.lastIndexOf('/')), this.url.slice(this.url.lastIndexOf('/')+1)]
+      return [filePath, fileName]
     },
     contentId() {
       return this.$getResourceURL(this.url)

--- a/src/resources.js
+++ b/src/resources.js
@@ -62,6 +62,10 @@ function resolvePath(url, root_dir) {
   if (resource_path.startsWith("assets://")) {
     resource_path = path.join(root_dir, resource_path.replace(/^assets:\/\//, ''))
     // logger.debug("[resPath]", url, "to", resource_path)
+  }  
+  else if (resource_path.startsWith(assets_root)) {
+    resource_path = path.join(root_dir, resource_path.replace(assets_root, ''))
+    // logger.debug("[resPath]", url, "to", resource_path)
   } else {
     // logger.debug("[resPath]", "no change for", resource_path)
   }


### PR DESCRIPTION
Resolves issue where resource links that fell back to `assets_root` instead of `asset://` would behave differently when trying to resolve their path. This affects the behavior of multiple context menu items, as well as casual references to the resource path (like below the media modal).

![image](https://user-images.githubusercontent.com/28245739/154828123-8c7d451f-ee0f-42fe-8837-93cb5247cc5b.png)
