### PR TITLE
Update actions to versions using node 24 because of the deprecation of node 20

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -64,7 +64,7 @@ jobs:
     # Platform-agnostic build
     steps:
     - uses: actions/checkout@v6
-    - uses: mskelton/setup-yarn@v1.4.0
+    - uses: mskelton/setup-yarn@v3
       with:
         node-version: "${{ env.NODE_VERSION }}"
     - run: make install

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -63,7 +63,7 @@ jobs:
 
     # Platform-agnostic build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: mskelton/setup-yarn@v1.4.0
       with:
         node-version: "${{ env.NODE_VERSION }}"

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -64,7 +64,7 @@ jobs:
     # Platform-agnostic build
     steps:
     - uses: actions/checkout@v6
-    - uses: mskelton/setup-yarn@v3
+    - uses: mskelton/setup-yarn@v4.0.0
       with:
         node-version: "${{ env.NODE_VERSION }}"
     - run: make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     # Platform-agnostic build
     steps:
     - uses: actions/checkout@v6
-    - uses: mskelton/setup-yarn@v3
+    - uses: mskelton/setup-yarn@v4.0.0
       with:
         node-version: "${{ env.NODE_VERSION }}"
     - run: make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     # Platform-agnostic build
     steps:
     - uses: actions/checkout@v6
-    - uses: mskelton/setup-yarn@v1.4.0
+    - uses: mskelton/setup-yarn@v3
       with:
         node-version: "${{ env.NODE_VERSION }}"
     - run: make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
     # Platform-agnostic build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: mskelton/setup-yarn@v1.4.0
       with:
         node-version: "${{ env.NODE_VERSION }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,10 +19,10 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
       with:
         languages: 'javascript'
         queries: security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -1,5 +1,5 @@
 name: "Todo Workflow"
- 
+
 on:
   push:
     branches: develop
@@ -9,7 +9,7 @@ jobs:
     name: Create Issues from Todos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: develop
       - name: TODO to Issue

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -14,13 +14,11 @@ jobs:
           ref: develop
       - name: TODO to Issue
         id: todo
-        uses: alstr/todo-to-issue-action@v5.0
+        uses: alstr/todo-to-issue-action@v5.1
         with:
           REPO: ${{ github.repository }}
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LABEL: "// TODO:"
-          COMMENT_MARKER: "//"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
~~setup-yarn's latest version is still on node 20, so that one will still produce warnings.~~ Turns out my to setup-yarn already got merged.